### PR TITLE
refactor ('tag' jobs): call git-push-tag with adequate inputs.dry-run for testing

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -34,3 +34,8 @@ jobs:
       with:
         prelerease: test
         buildmeta: npm
+    - uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
+      with:
+        remote: origin
+        branch: main
+        dry-run: true

--- a/.github/workflows/build-cron.yml
+++ b/.github/workflows/build-cron.yml
@@ -33,3 +33,4 @@ jobs:
       with:
         remote: origin
         branch: main
+        dry-run: false

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -35,3 +35,9 @@ jobs:
       with:
         prelerease: test
         buildmeta: npm
+    - if: ${{ ! endsWith(github.ref_name, 'merge') }}
+      uses: kagekirin/gha-utils/.github/actions/git-push-tag@main
+      with:
+        remote: origin
+        branch: ${{ github.head_ref || github.ref_name }} # => the former for PR, the latter as fallback (regular push)
+        dry-run: true


### PR DESCRIPTION
- refactor ('build-cron/tag' job): provide inputs.dry-run(true) to git-push-tag
- refactor ('build-ci/tag' job): call git-push-tag with inputs.dry-run(false)
- refactor ('build-pr/tag' job): call git-push-tag with inputs.dry-run(false)
